### PR TITLE
Add SEO-friendly CV path and update domain links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 A lightweight, interactive terminal-style CV website featuring a retro 90s hacker aesthetic. Users navigate through content using familiar terminal commands in an authentic CRT-style interface.
 
+Live site: <https://goortani.com>
+
 ## 🚀 Features
 
 - **Interactive Terminal Interface**: Command-based navigation system

--- a/cv/index.html
+++ b/cv/index.html
@@ -3,22 +3,23 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Frank Goortani | Short CV — Terminal Edition</title>
-  <meta name="description" content="Concise CV of Frank Goortani - Technology Leader & AI Strategist. Experience in Generative AI, LLMs, cloud architecture, and mobile development. Interactive terminal interface.">
-  <meta name="keywords" content="Frank Goortani, Short CV, Solution Architect, AI Strategist, Resume, Terminal CV">
-  <link rel="canonical" href="https://goortani.com/short/">
+  <title>Frank Goortani | Full CV — Terminal Edition</title>
+  <meta name="description" content="Full CV of Frank Goortani - Technology Leader & AI Strategist. Experience in Generative AI, LLMs, cloud architecture, and mobile development. Interactive terminal interface.">
+  <meta name="keywords" content="Frank Goortani, Full CV, Solution Architect, AI Strategist, Resume, Terminal CV">
+  <link rel="canonical" href="https://goortani.com/cv/">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="profile">
-  <meta property="og:url" content="https://goortani.com/short/">
-  <meta property="og:title" content="Frank Goortani | Short CV — Terminal Edition">
-  <meta property="og:description" content="Concise CV of Frank Goortani - Technology Leader & AI Strategist specializing in Generative AI and cloud architecture.">
+  <meta property="og:url" content="https://goortani.com/cv/">
+  <meta property="og:title" content="Frank Goortani | Full CV — Terminal Edition">
+  <meta property="og:description" content="Full CV of Frank Goortani - Technology Leader & AI Strategist specializing in Generative AI and cloud architecture.">
   <meta property="og:image" content="https://goortani.com/og-image.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="Frank Goortani | Short CV">
-  <meta name="twitter:description" content="Concise CV of Technology Leader & AI Strategist specializing in Generative AI and cloud architecture.">
+  <meta name="twitter:title" content="Frank Goortani | Full CV">
+  <meta name="twitter:description" content="Full CV of Technology Leader & AI Strategist specializing in Generative AI and cloud architecture.">
+  <meta name="twitter:image" content="https://goortani.com/twitter-card.png">
 
   <meta name="robots" content="index, follow">
 
@@ -36,11 +37,11 @@
   <div class="screen">
     <div class="term" role="region" aria-label="terminal">
       <div class="header">
-        <div class="brand glow">GOORTANI::CV[short]</div>
+        <div class="brand glow">GOORTANI::CV[full]</div>
         <div class="nav-inline">
           <span class="badge">Terminal</span>
           <a href="../" title="Home">Home</a>
-          <a href="./" title="Short CV">Short</a>
+          <a href="../short/" title="Short CV">Short</a>
           <a href="https://medium.com/@FrankGoortani" title="Blog">Blog</a>
           <a href="mailto:frank@goortani.com" title="Email Frank">Email</a>
           <a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf" target="_blank" rel="noopener" title="PDF Resume">Download&nbsp;PDF</a>
@@ -51,23 +52,23 @@
 
       <div class="prompt" aria-label="command prompt">
         <span class="prompt-label glow">$</span>
-        <input id="cmd" type="text" autocomplete="off" spellcheck="false" placeholder="type commands (try: help, short, links)">
+        <input id="cmd" type="text" autocomplete="off" spellcheck="false" placeholder="type commands (try: help, cv, links)">
         <span class="cursor" aria-hidden="true"></span>
       </div>
 
       <div class="footer">
-        <span>Tip: Type <kbd>short</kbd> to view concise CV. Use <kbd>links</kbd> for quick navigation.</span>
+        <span>Tip: Type <kbd>cv</kbd> to view full CV. Use <kbd>links</kbd> for quick navigation.</span>
       </div>
     </div>
   </div>
   <script defer src="../terminal.js"></script>
   <script>
-    // Auto-show short CV on load
+    // Auto-show full CV on load
     window.addEventListener("DOMContentLoaded", () => {
       setTimeout(() => {
         const evt = new KeyboardEvent('keydown', {key: 'Enter'});
         const input = document.getElementById('cmd');
-        input.value = 'short';
+        input.value = 'cv';
         input.dispatchEvent(evt);
         input.focus();
       }, 50);

--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
   <meta name="description" content="Frank Goortani — Technology Leader & AI Strategist with 25+ years experience in Generative AI, LLMs, cloud architecture, and mobile development. Interactive terminal-style CV.">
   <meta name="keywords" content="Frank Goortani, Solution Architect, AI Strategist, LLM, Generative AI, Cloud Architecture, Mobile Development, Python, Go, TypeScript, React, Terminal CV">
   <meta name="author" content="Frank Goortani">
-  <link rel="canonical" href="https://goortani.github.io/goortani-terminal-site/">
+  <link rel="canonical" href="https://goortani.com/">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="profile">
-  <meta property="og:url" content="https://goortani.github.io/goortani-terminal-site/">
+  <meta property="og:url" content="https://goortani.com/">
   <meta property="og:title" content="Frank Goortani | Technology Leader & AI Strategist">
   <meta property="og:description" content="Experienced Solution Architect specializing in Generative AI, LLMs, and cloud-native architectures. Interactive terminal-style CV showcasing 25+ years of technology leadership.">
-  <meta property="og:image" content="https://goortani.github.io/goortani-terminal-site/og-image.png">
+  <meta property="og:image" content="https://goortani.com/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:site_name" content="Frank Goortani CV">
@@ -23,10 +23,10 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:url" content="https://goortani.github.io/goortani-terminal-site/">
+  <meta name="twitter:url" content="https://goortani.com/">
   <meta name="twitter:title" content="Frank Goortani | Technology Leader & AI Strategist">
   <meta name="twitter:description" content="Experienced Solution Architect specializing in Generative AI, LLMs, and cloud-native architectures. Interactive terminal-style CV.">
-  <meta name="twitter:image" content="https://goortani.github.io/goortani-terminal-site/twitter-card.png">
+  <meta name="twitter:image" content="https://goortani.com/twitter-card.png">
   <meta name="twitter:creator" content="@FrankGoortani">
 
   <!-- Favicon and Icons -->
@@ -81,8 +81,8 @@
     "name": "Frank Goortani",
     "jobTitle": "Solution Architect & AI Strategist",
     "description": "Technology Leader with 25+ years experience in Generative AI, LLMs, cloud architecture, and mobile development",
-    "url": "https://goortani.github.io/goortani-terminal-site/",
-    "image": "https://goortani.github.io/goortani-terminal-site/profile-image.jpg",
+    "url": "https://goortani.com/",
+    "image": "https://goortani.com/profile-image.jpg",
     "sameAs": [
       "https://www.linkedin.com/in/frankgoortani/",
       "https://twitter.com/FrankGoortani",

--- a/llm.txt
+++ b/llm.txt
@@ -6,8 +6,8 @@ Use of this content to train large language models or other automated systems is
 
 ## Key Pages
 
-- [Full CV](https://goortani.com) - comprehensive résumé detailing Frank's experience.
-- [Short CV](https://goortani.com/short) - quick overview of qualifications.
-- [Blog](https://goortani.com/blog) - articles on technology leadership and AI.
+- [Full CV](https://goortani.com/cv/) - comprehensive résumé detailing Frank's experience.
+- [Short CV](https://goortani.com/short/) - quick overview of qualifications.
+- [Blog](https://medium.com/@FrankGoortani) - articles on technology leadership and AI.
 - [Chatbot Documentation](https://goortani.com/chatbotdoc) - usage guide for the site assistant.
 - [Source Repository](https://github.com/FrankGoortani/markdown-cv) - site source and issue tracking.

--- a/robots.txt
+++ b/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # Sitemap
-Sitemap: https://goortani.github.io/goortani-terminal-site/sitemap.xml
+Sitemap: https://goortani.com/sitemap.xml
 
 # Crawl-delay for polite crawling
 Crawl-delay: 1

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://goortani.github.io/goortani-terminal-site/</loc>
+    <loc>https://goortani.com/</loc>
     <lastmod>2025-01-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://goortani.github.io/goortani-terminal-site/short/</loc>
+    <loc>https://goortani.com/short/</loc>
     <lastmod>2025-01-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://goortani.com/cv/</loc>
+    <lastmod>2025-01-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
   </url>
 </urlset>

--- a/terminal.js
+++ b/terminal.js
@@ -6,9 +6,15 @@
   const out = $("#out");
   const input = $("#cmd");
 
+  // determine base path relative to site root for subdirectory pages
+  const rootPath = (() => {
+    const depth = window.location.pathname.split("/").filter(Boolean).length;
+    return depth ? "../".repeat(depth) : "./";
+  })();
+
   const links = {
     resume_pdf: "https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf",
-    short: "./short/",
+    short: rootPath + "short/",
     blog: "https://medium.com/@FrankGoortani",
     linkedin: "https://www.linkedin.com/in/frankgoortani/",
     stackoverflow: "https://stackoverflow.com/users/1136641/frank-goortani",
@@ -78,16 +84,9 @@
   const cache = {};
   // Resolve content paths relative to site root, regardless of current page location
   function resolvePath(contentPath) {
-    const currentPath = window.location.pathname;
-    const isInSubdirectory = currentPath.includes('/short/');
-
-    if (isInSubdirectory) {
-      // From /short/ page, need to go up one level to reach content
-      return '../' + contentPath.replace('./', '');
-    } else {
-      // From root page, use path as-is
-      return contentPath;
-    }
+    const depth = window.location.pathname.split("/").filter(Boolean).length;
+    if (depth === 0) return contentPath;
+    return "../".repeat(depth) + contentPath.replace("./", "");
   }
 
   async function load(path){


### PR DESCRIPTION
## Summary
- create `/cv/` page that auto-loads the full CV and exposes SEO meta tags
- generalize terminal routing to handle subdirectory pages and adjust internal links
- update sitemap, robots, and canonical URLs to use goortani.com
- document canonical goortani.com domain and direct CV links in README and llm metadata

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae1fd31a7c832d8b55275c7d56b059