### PR TITLE
Add standalone resume page and update links

### DIFF
--- a/content/cv-full.html
+++ b/content/cv-full.html
@@ -60,7 +60,7 @@ hr {
   <p>Technology Leader &amp; AI Strategist | LLM, Web, Cloud, Mobile</p>
   <div id="webaddress">
     <a href="mailto:frank@goortani.com">frank@goortani.com</a> |
-    <a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf" target="_blank">Download PDF</a> |
+    <a href="/resume/" target="_blank">Download PDF</a> |
     <a href="../short/" target="_blank">View short version</a> |
     <a href="https://medium.com/@FrankGoortani" target="_blank">Blog</a>
   </div>
@@ -462,7 +462,7 @@ B.Sc. in Computer Software Engineering</p>
   <li><a href="https://stackoverflow.com/users/1136641/frank-goortani">StackOverflow</a></li>
   <li><a href="https://twitter.com/FrankGoortani">Twitter</a></li>
   <li><a href="https://medium.com/@FrankGoortani">Medium</a></li>
-  <li><a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf">Resume</a></li>
+  <li><a href="/resume/">Resume</a></li>
   <li><a href="https://github.com/frankgoortani">GitHub</a></li>
   <li><a href="https://calendly.com/frankgoortani">Calendly</a></li>
   <li><a href="https://www.producthunt.com/@frankgoortani">ProductHunt</a></li>

--- a/content/cv-short.html
+++ b/content/cv-short.html
@@ -60,7 +60,7 @@ hr {
   <p>Technology Leader &amp; AI Strategist | LLM, Web, Cloud, Mobile</p>
   <div id="webaddress">
     <a href="mailto:frank@goortani.com">frank@goortani.com</a> |
-    <a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf" target="_blank">Download PDF</a> |
+    <a href="/resume/" target="_blank">Download PDF</a> |
     <a href="../" target="_blank">View detailed version</a> |
     <a href="https://medium.com/@FrankGoortani" target="_blank">Blog</a>
   </div>
@@ -287,7 +287,7 @@ B.Sc. in Computer Software Engineering</p>
   <li><a href="https://stackoverflow.com/users/1136641/frank-goortani">StackOverflow</a></li>
   <li><a href="https://twitter.com/FrankGoortani">Twitter</a></li>
   <li><a href="https://medium.com/@FrankGoortani">Medium</a></li>
-  <li><a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf">Resume</a></li>
+  <li><a href="/resume/">Resume</a></li>
   <li><a href="https://github.com/frankgoortani">GitHub</a></li>
   <li><a href="https://www.producthunt.com/@frankgoortani">ProductHunt</a></li>
   <li><a href="https://architect.solutions">Architect Solutions</a></li>

--- a/content/links.json
+++ b/content/links.json
@@ -1,6 +1,6 @@
 {
   "email": "mailto:frank@goortani.com",
-  "resume_pdf": "https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf",
+  "resume_pdf": "https://goortani.com/resume/",
   "short": "./short/",
   "blog": "https://medium.com/@FrankGoortani",
   "linkedin": "https://www.linkedin.com/in/frankgoortani/",

--- a/cv/index.html
+++ b/cv/index.html
@@ -44,7 +44,7 @@
           <a href="../short/" title="Short CV">Short</a>
           <a href="https://medium.com/@FrankGoortani" title="Blog">Blog</a>
           <a href="mailto:frank@goortani.com" title="Email Frank">Email</a>
-          <a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf" target="_blank" rel="noopener" title="PDF Resume">Download&nbsp;PDF</a>
+          <a href="/resume/" target="_blank" rel="noopener" title="PDF Resume">Download&nbsp;PDF</a>
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
           <a href="./short/" title="Short CV">Short</a>
           <a href="https://medium.com/@FrankGoortani" title="Blog">Blog</a>
           <a href="mailto:frank@goortani.com" title="Email Frank">Email</a>
-          <a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf" target="_blank" rel="noopener" title="PDF Resume">Download&nbsp;PDF</a>
+          <a href="/resume/" target="_blank" rel="noopener" title="PDF Resume">Download&nbsp;PDF</a>
         </div>
       </div>
 

--- a/resume/index.html
+++ b/resume/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Frank Goortani | Resume (PDF)</title>
+  <meta name="description" content="Professional resume of Frank Goortani in PDF format.">
+  <link rel="canonical" href="https://goortani.com/resume/">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
+  <meta name="robots" content="noindex">
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+    }
+    .pdf-container {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <object data="../media/Frank%20Goortani%20Resume--solution-architect-2025.pdf" type="application/pdf" class="pdf-container">
+    <p>Your browser does not support PDFs. <a href="../media/Frank%20Goortani%20Resume--solution-architect-2025.pdf">Download the PDF</a>.</p>
+  </object>
+</body>
+</html>

--- a/short/index.html
+++ b/short/index.html
@@ -43,7 +43,7 @@
           <a href="./" title="Short CV">Short</a>
           <a href="https://medium.com/@FrankGoortani" title="Blog">Blog</a>
           <a href="mailto:frank@goortani.com" title="Email Frank">Email</a>
-          <a href="https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf" target="_blank" rel="noopener" title="PDF Resume">Download&nbsp;PDF</a>
+          <a href="/resume/" target="_blank" rel="noopener" title="PDF Resume">Download&nbsp;PDF</a>
         </div>
       </div>
 

--- a/terminal.js
+++ b/terminal.js
@@ -13,7 +13,7 @@
   })();
 
   const links = {
-    resume_pdf: "https://goortani.com/media/Frank%20Goortani%20Resume--solution-architect-2025.pdf",
+    resume_pdf: rootPath + "resume/",
     short: rootPath + "short/",
     blog: "https://medium.com/@FrankGoortani",
     linkedin: "https://www.linkedin.com/in/frankgoortani/",


### PR DESCRIPTION
## Summary
- add `/resume/` page that embeds the PDF resume for seamless viewing
- update navigation, content, and terminal commands to point to the new resume page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae2ed2d4c8832db7f40aef6cd4c496